### PR TITLE
skip tmpfs requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ First we start the container:
 docker run --detach --restart=always --log-opt max-size=10m \
 	--cpus=1 --memory=64m --memory-reservation=64m \
 	--cap-add=SYS_ADMIN --cap-add=NET_RAW --cap-add=CHOWN \
-	--mount type=tmpfs,destination=/var/atlasdata,tmpfs-size=64M \
 	-v /var/atlas-probe/etc:/var/atlas-probe/etc \
 	-v /var/atlas-probe/status:/var/atlas-probe/status \
 	-e RXTXRPT=yes \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ mkdir -p /var/atlas-probe/etc
 chown -R atlas:atlas /var/atlas-probe/etc
 mkdir -p /var/atlas-probe/state
 chown -R atlas:atlas /var/atlas-probe/state
-echo "" > "${CONFIG_FILE}"
+echo "CHECK_ATLASDATA_TMPFS=no" > "${CONFIG_FILE}"
 
 # set probe configuration
 for OPT in "${OPTIONS[@]}"; do


### PR DESCRIPTION
since servers don't need tmpfs and CentOS 7 docker is too old to support --mount, use the config option CHECK_ATLASDATA_TMPFS=no to skip it