### PR TITLE
Allow custom UID/GID

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,14 @@ if ! sleep 0 >/dev/null 2>&1; then
 	>&2 echo "WARNING: clock_nanosleep or clock_nanosleep_time64 is not available on the system"
 fi
 
+export ATLAS_UID="${ATLAS_UID:-101}"
+export ATLAS_GID="${ATLAS_GID:-999}"
+
+usermod -u $ATLAS_UID atlas
+groupmod -g $ATLAS_GID atlas
+chown -R atlas:atlas /var/atlas-probe
+chown -R atlas:atlas /var/atlasdata
+
 # create essential files and fix permission
 mkdir -p /var/atlas-probe/status
 chown -R atlas:atlas /var/atlas-probe/status


### PR DESCRIPTION
Allowing users to run the software probe with custom UID/GID

Usage:
Add `ATLAS_UID` and `ATLAS_GID` environment variable to switch the atlas process uid/gid

Example:
```
docker run --detach --restart=always \
    --log-driver json-file --log-opt max-size=10m \
    --cpus=1 --memory=64m --memory-reservation=64m \
    --cap-drop=ALL --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=DAC_OVERRIDE --cap-add=NET_RAW \
    -v /var/atlas-probe/etc:/var/atlas-probe/etc \
    -v /var/atlas-probe/status:/var/atlas-probe/status \
    -e RXTXRPT=yes \
    --network=host \
    -e ATLAS_UID=13335 -e ATLAS_GID=13335 \
    --name ripe-atlas \
    kskbsi/ripe-atlas:latest
```