### PR TITLE
remove unneded chown commands in the entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,16 +16,7 @@ export ATLAS_GID="${ATLAS_GID:-999}"
 
 usermod -u $ATLAS_UID atlas
 groupmod -g $ATLAS_GID atlas
-chown -R atlas:atlas /var/atlas-probe
-chown -R atlas:atlas /var/atlasdata
 
-# create essential files and fix permission
-mkdir -p /var/atlas-probe/status
-chown -R atlas:atlas /var/atlas-probe/status
-mkdir -p /var/atlas-probe/etc
-chown -R atlas:atlas /var/atlas-probe/etc
-mkdir -p /var/atlas-probe/state
-chown -R atlas:atlas /var/atlas-probe/state
 echo "CHECK_ATLASDATA_TMPFS=no" > "${CONFIG_FILE}"
 
 # set probe configuration


### PR DESCRIPTION
no need to chown the dirs for as long these are defined in the Dockerfile