### PR TITLE
Use setpriv instead of gosu / fix Podman SIGTERM failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN ln -s /bin/true /bin/systemctl \
 	&& groupadd --force --system --gid $ATLAS_GID atlas \
 	&& usermod -aG atlas atlas \
 	&& apt-get update -y \
-	&& apt-get install -y libcap2-bin iproute2 openssh-client procps net-tools gosu \
+	&& apt-get install -y libcap2-bin iproute2 openssh-client procps net-tools \
 	&& dpkg -i /tmp/atlasswprobe-*.deb \
 	&& apt-get install -fy \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN ln -s /bin/true /bin/systemctl \
 	&& groupadd --force --system --gid $ATLAS_GID atlas \
 	&& usermod -aG atlas atlas \
 	&& apt-get update -y \
-	&& apt-get install -y libcap2-bin iproute2 openssh-client procps net-tools \
+	&& apt-get install -y libcap2-bin iproute2 openssh-client procps net-tools tini \
 	&& dpkg -i /tmp/atlasswprobe-*.deb \
 	&& apt-get install -fy \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -72,5 +72,5 @@ RUN chmod +x /usr/local/bin/* \
 WORKDIR /var/atlas-probe
 VOLUME [ "/var/atlas-probe/etc", "/var/atlas-probe/status" ]
 
-ENTRYPOINT [ "entrypoint.sh" ]
+ENTRYPOINT [ "tini", "--", "entrypoint.sh" ]
 CMD [ "atlas" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,4 +38,4 @@ for OPT in "${OPTIONS[@]}"; do
 	fi
 done
 
-exec gosu atlas:atlas "$@"
+exec setpriv --reuid=$ATLAS_UID --regid=$ATLAS_GID --init-groups "$@"


### PR DESCRIPTION
`setpriv` is already included in Debian 10+'s `util-linux`, I guess we no longer need `gosu` anymore.