### PR TITLE
Also publish images to GitHub Container Registry

### DIFF
--- a/.github/workflows/container-image-publish.yml
+++ b/.github/workflows/container-image-publish.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -24,12 +27,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
       - uses: docker/metadata-action@v5
         id: metadata-probe
         with:
           bake-target: ripe-atlas-probe
-          images: docker.io/jamesits/ripe-atlas
+          images: |
+            docker.io/jamesits/ripe-atlas
+            ghcr.io/jamesits/ripe-atlas
           flavor: |
             latest=false
           tags: |
@@ -43,7 +53,9 @@ jobs:
         id: metadata-anchor
         with:
           bake-target: ripe-atlas-anchor
-          images: docker.io/jamesits/ripe-atlas
+          images: |
+            docker.io/jamesits/ripe-atlas
+            ghcr.io/jamesits/ripe-atlas
           flavor: |
             latest=false
           tags: |

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,9 @@ variable "CR_DOCKER_HUB_PREFIX" {
 variable "IMAGE_TAG_PREFIX" {
     default = "docker.io/jamesits/ripe-atlas"
 }
+variable "IMAGE_GHCR_TAG_PREFIX" {
+    default = "ghcr.io/jamesits/ripe-atlas"
+}
 
 group "default" {
     targets = ["artifacts", "ripe-atlas-probe", "ripe-atlas-anchor"]
@@ -43,6 +46,8 @@ target "_ripe-atlas-probe" {
     tags = [
         "${IMAGE_TAG_PREFIX}:latest",
         "${IMAGE_TAG_PREFIX}:latest-probe",
+        "${IMAGE_GHCR_TAG_PREFIX}:latest",
+        "${IMAGE_GHCR_TAG_PREFIX}:latest-probe",
     ]
 }
 
@@ -58,6 +63,7 @@ target "_ripe-atlas-anchor" {
     ]
     tags = [
         "${IMAGE_TAG_PREFIX}:latest-anchor",
+        "${IMAGE_GHCR_TAG_PREFIX}:latest-anchor",
     ]
 }
 


### PR DESCRIPTION
Add support to also publish the container images to GitHub Container Registry (GHCR)

[Docker Hub](https://docs.docker.com/docker-hub/usage/) has painful registry usage limits.
